### PR TITLE
Pages 無効時はデプロイをスキップするワークフロー追加

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,7 +16,33 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  check_pages:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - name: Check GitHub Pages status
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.request('GET /repos/{owner}/{repo}/pages', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              core.setOutput('enabled', 'true');
+            } catch (error) {
+              if (error.status === 404) {
+                core.setOutput('enabled', 'false');
+                core.info('GitHub Pages is not enabled; skipping deploy job.');
+                return;
+              }
+              throw error;
+            }
+
   build:
+    needs: check_pages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,6 +55,7 @@ jobs:
 
   deploy:
     needs: build
+    if: needs.check_pages.outputs.enabled == 'true'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
### Motivation
- `actions/deploy-pages` が Pages 未有効時に 404 エラーで失敗するため、ワークフローが不要に失敗するのを防ぐ目的で変更を加えた。 
- Pages が有効な場合は従来通りデプロイを行いたいという要件に対応するための変更である。 

### Description
- `.github/workflows/pages.yml` に `check_pages` ジョブを追加し、`actions/github-script@v7` で `GET /repos/{owner}/{repo}/pages` を呼び出して Pages の有効性を判定し出力 `enabled` を設定した。 
- `build` ジョブを `needs: check_pages` に変更し、`deploy` ジョブに `if: needs.check_pages.outputs.enabled == 'true'` を追加して Pages が有効な場合のみデプロイするようにした。 
- 既存のアーティファクトアップロード `actions/upload-pages-artifact@v3` とデプロイ `actions/deploy-pages@v4` の動作は維持している。 

### Testing
- 自動化テストやワークフロー実行は行っておらず、ワークフロー定義の変更のみであるため自動テストは未実行である。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b46273a088333ab911b3b5b648290)