### PR TITLE
フェーズ別ビープ音とUIの調整

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,6 +60,12 @@ const phases = [
   { key: Phase.UP, duration: () => parseInt(upDurationInput.value, 10) },
 ];
 
+const phaseBeepFrequencies = {
+  [Phase.DOWN]: 620,
+  [Phase.HOLD]: 880,
+  [Phase.UP]: 520,
+};
+
 const beep = (frequency = 880, duration = 150) => {
   if (!audioContext) {
     audioContext = new (window.AudioContext || window.webkitAudioContext)();
@@ -100,7 +106,8 @@ const setPhase = (phaseKey, durationSeconds, hint) => {
   phaseHint.textContent = hint;
   updateDisplays();
   updateTimerUI();
-  beep();
+  const phaseFrequency = phaseBeepFrequencies[phaseKey];
+  beep(phaseFrequency ?? 880);
 };
 
 const nextRepOrSet = () => {

--- a/index.html
+++ b/index.html
@@ -15,15 +15,15 @@
 
       <section class="panel">
         <div class="status">
-          <div>
+          <div class="status-item">
             <span class="label">セット</span>
             <span id="set-display" class="value">1 / 3</span>
           </div>
-          <div>
+          <div class="status-item">
             <span class="label">回数</span>
             <span id="rep-display" class="value">1 / 10</span>
           </div>
-          <div>
+          <div class="status-item phase-status">
             <span class="label">フェーズ</span>
             <span id="phase-display" class="value">待機中</span>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -50,6 +50,12 @@ header h1 {
   gap: 12px;
 }
 
+.status-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .status .label {
   display: block;
   font-size: 0.9rem;
@@ -59,6 +65,20 @@ header h1 {
 .status .value {
   font-size: 1.4rem;
   font-weight: 600;
+}
+
+.phase-status {
+  grid-column: 1 / -1;
+  text-align: center;
+}
+
+.phase-status .label {
+  font-size: 1rem;
+}
+
+.phase-status .value {
+  font-size: 2.1rem;
+  letter-spacing: 0.08em;
 }
 
 .timer {
@@ -93,16 +113,16 @@ header h1 {
 
 .controls {
   background: white;
-  padding: 20px;
+  padding: 16px;
   border-radius: 20px;
   box-shadow: 0 8px 24px rgba(35, 24, 84, 0.08);
   display: grid;
-  gap: 16px;
+  gap: 12px;
 }
 
 .control-group {
   display: grid;
-  gap: 12px;
+  gap: 10px;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
@@ -115,10 +135,10 @@ label {
 }
 
 input[type="number"] {
-  padding: 8px 10px;
+  padding: 6px 10px;
   border-radius: 10px;
   border: 1px solid #dad5f5;
-  font-size: 1rem;
+  font-size: 0.95rem;
 }
 
 .modes {


### PR DESCRIPTION
### Motivation
- `beep` の音程をフェーズ（しゃがむ・キープ・立つ）で区別してリズム把握を助けるため。 
- フェーズ表示をより大きくセンターに配置して視認性を向上させるため。 
- パラメータ編集パネルをコンパクトにして狭い画面でも入力操作をしやすくするため。

### Description
- フェーズごとの周波数マッピングとして `phaseBeepFrequencies` を追加し、`setPhase` から `beep` を対応周波数で呼び出すようにしました。 
- フェーズ表示を中央で強調するために `index.html` のステータス要素に `status-item` と `phase-status` クラスを追加しました。 
- レイアウトを詰めるために `styles.css` を更新し、`.controls` の `padding`、`.control-group` の `gap`、および `input[type="number"]` の `padding` と `font-size` を調整しました。 
- フェーズ表示のフォントサイズと配置を改善するスタイルを追加して視認性を向上させました。

### Testing
- `python -m http.server` を起動し、`playwright` 経由で `index.html` のスクリーンショットを取得するUI確認を実行し、スクリーンショット取得は成功しました。 
- ユニットテストや自動化テストの実行は行っておらず、ユニットテストは未実行です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b4dd133a083339f16eb29197055e4)