### PR TITLE
ビープ音を心地よい音色に変更

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,24 +61,26 @@ const phases = [
 ];
 
 const phaseBeepFrequencies = {
-  [Phase.DOWN]: 620,
-  [Phase.HOLD]: 880,
-  [Phase.UP]: 520,
+  [Phase.DOWN]: 523.25,
+  [Phase.HOLD]: 659.25,
+  [Phase.UP]: 784,
 };
 
-const beep = (frequency = 880, duration = 150) => {
+const beep = (frequency = 659.25, duration = 150) => {
   if (!audioContext) {
     audioContext = new (window.AudioContext || window.webkitAudioContext)();
   }
+  const now = audioContext.currentTime;
   const oscillator = audioContext.createOscillator();
   const gain = audioContext.createGain();
-  oscillator.frequency.value = frequency;
-  gain.gain.value = 0.2;
+  oscillator.type = 'sine';
+  oscillator.frequency.setValueAtTime(frequency, now);
+  gain.gain.setValueAtTime(0, now);
+  gain.gain.linearRampToValueAtTime(0.18, now + 0.02);
+  gain.gain.exponentialRampToValueAtTime(0.0001, now + duration / 1000);
   oscillator.connect(gain).connect(audioContext.destination);
-  oscillator.start();
-  setTimeout(() => {
-    oscillator.stop();
-  }, duration);
+  oscillator.start(now);
+  oscillator.stop(now + duration / 1000 + 0.05);
 };
 
 const updateDisplays = () => {


### PR DESCRIPTION
### Motivation
- ビープ音が耳に痛く感じられるため、通知音をより心地よい音色に変更するための対応です。

### Description
- `app.js` の `phaseBeepFrequencies` をメロディックな周波数（`Phase.DOWN`: 523.25Hz、`Phase.HOLD`: 659.25Hz、`Phase.UP`: 784Hz）に更新しました。
- `beep` 関数のデフォルト周波数を `659.25`Hz に変更し、`oscillator.type` を `sine` に設定しました。
- Web Audio API の `currentTime` を用いて再生開始/停止をスケジュールし、`gain` に対して短いアタック（線形）と持続中の指数的な減衰を与えるエンベロープを追加して音を柔らかくしました。
- すべての変更は `app.js` に実装されています。

### Testing
- 自動テストは実行していません（未依頼）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b6902893c83339d3197d54f6faee5)