### PR TITLE
Squat Tracker にダークモード切替を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,9 +20,24 @@ const resetButton = document.getElementById('reset-button');
 const sensorToggle = document.getElementById('sensor-toggle');
 const sensorCalibrateButton = document.getElementById('sensor-calibrate');
 const sensorStatus = document.getElementById('sensor-status');
+const themeToggle = document.getElementById('theme-toggle');
 
 const confettiCanvas = document.getElementById('confetti');
 const confettiCtx = confettiCanvas.getContext('2d');
+
+const getPreferredTheme = () => {
+  const storedTheme = localStorage.getItem('theme');
+  if (storedTheme === 'light' || storedTheme === 'dark') {
+    return storedTheme;
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
+const applyTheme = (theme) => {
+  document.documentElement.setAttribute('data-theme', theme);
+  themeToggle.setAttribute('aria-pressed', theme === 'dark');
+  themeToggle.textContent = theme === 'dark' ? 'ライトモード' : 'ダークモード';
+};
 
 const Phase = {
   IDLE: '待機中',
@@ -334,6 +349,12 @@ sensorCalibrateButton.addEventListener('click', () => {
   sensorStatus.textContent = '角度を再計測します。逆さまに固定して数秒待ってください。';
 });
 
+themeToggle.addEventListener('click', () => {
+  const nextTheme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+  localStorage.setItem('theme', nextTheme);
+  applyTheme(nextTheme);
+});
+
 const launchConfetti = () => {
   confettiCanvas.width = window.innerWidth;
   confettiCanvas.height = window.innerHeight;
@@ -373,4 +394,5 @@ const stopConfetti = () => {
   confettiCtx.clearRect(0, 0, confettiCanvas.width, confettiCanvas.height);
 };
 
+applyTheme(getPreferredTheme());
 updateDisplays();

--- a/index.html
+++ b/index.html
@@ -9,7 +9,12 @@
   <body>
     <main class="app">
       <header>
-        <h1>Squat Tracker</h1>
+        <div class="header-row">
+          <h1>Squat Tracker</h1>
+          <button id="theme-toggle" class="ghost" type="button" aria-pressed="false">
+            ダークモード
+          </button>
+        </div>
         <p class="subtitle">毎日のスクワットをリズムに合わせて記録しよう。</p>
       </header>
 

--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,42 @@
   font-family: "Segoe UI", "Hiragino Kaku Gothic ProN", sans-serif;
   background: #f7f5ff;
   color: #1c1b29;
+  --bg: #f7f5ff;
+  --bg-gradient: linear-gradient(180deg, #efe9ff, #fdfcff);
+  --text: #1c1b29;
+  --muted: #5f5b7a;
+  --panel-bg: #ffffff;
+  --panel-shadow: 0 12px 30px rgba(35, 24, 84, 0.1);
+  --panel-shadow-soft: 0 8px 24px rgba(35, 24, 84, 0.08);
+  --border: #dad5f5;
+  --button-bg: #e8e4ff;
+  --button-text: #1c1b29;
+  --ghost-border: #d7d2f0;
+  --accent: #6d5afc;
+  --accent-strong: #7c5cff;
+  --accent-cool: #4cc9f0;
+  --progress-bg: #ebe7ff;
+}
+
+html[data-theme="dark"] {
+  color-scheme: dark;
+  background: #0f0d18;
+  color: #f4f2ff;
+  --bg: #0f0d18;
+  --bg-gradient: linear-gradient(180deg, #1a132e, #0f0d18);
+  --text: #f4f2ff;
+  --muted: #b0aac7;
+  --panel-bg: #1a1629;
+  --panel-shadow: 0 12px 30px rgba(8, 6, 20, 0.4);
+  --panel-shadow-soft: 0 8px 24px rgba(8, 6, 20, 0.35);
+  --border: #322a52;
+  --button-bg: #2e2842;
+  --button-text: #f4f2ff;
+  --ghost-border: #3d345d;
+  --accent: #9a86ff;
+  --accent-strong: #a08bff;
+  --accent-cool: #55d6ff;
+  --progress-bg: #2c2445;
 }
 
 * {
@@ -13,7 +49,8 @@ body {
   margin: 0;
   padding: 0;
   min-height: 100vh;
-  background: linear-gradient(180deg, #efe9ff, #fdfcff);
+  background: var(--bg-gradient);
+  color: var(--text);
 }
 
 .app {
@@ -30,16 +67,24 @@ header h1 {
   font-size: 2.4rem;
 }
 
+.header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
 .subtitle {
   margin: 0;
-  color: #5f5b7a;
+  color: var(--muted);
 }
 
 .panel {
-  background: white;
+  background: var(--panel-bg);
   padding: 24px;
   border-radius: 20px;
-  box-shadow: 0 12px 30px rgba(35, 24, 84, 0.1);
+  box-shadow: var(--panel-shadow);
   display: grid;
   gap: 24px;
 }
@@ -59,7 +104,7 @@ header h1 {
 .status .label {
   display: block;
   font-size: 0.9rem;
-  color: #7b7696;
+  color: var(--muted);
 }
 
 .status .value {
@@ -92,14 +137,14 @@ header h1 {
 }
 
 .timer-hint {
-  color: #5f5b7a;
+  color: var(--muted);
   margin-bottom: 12px;
 }
 
 .progress {
   width: 100%;
   height: 10px;
-  background: #ebe7ff;
+  background: var(--progress-bg);
   border-radius: 999px;
   overflow: hidden;
 }
@@ -107,15 +152,15 @@ header h1 {
 .progress-bar {
   width: 0;
   height: 100%;
-  background: linear-gradient(90deg, #7c5cff, #4cc9f0);
+  background: linear-gradient(90deg, var(--accent-strong), var(--accent-cool));
   transition: width 0.1s linear;
 }
 
 .controls {
-  background: white;
+  background: var(--panel-bg);
   padding: 16px;
   border-radius: 20px;
-  box-shadow: 0 8px 24px rgba(35, 24, 84, 0.08);
+  box-shadow: var(--panel-shadow-soft);
   display: grid;
   gap: 12px;
 }
@@ -131,13 +176,15 @@ label {
   flex-direction: column;
   gap: 6px;
   font-size: 0.9rem;
-  color: #5c5876;
+  color: var(--muted);
 }
 
 input[type="number"] {
   padding: 6px 10px;
   border-radius: 10px;
-  border: 1px solid #dad5f5;
+  border: 1px solid var(--border);
+  background: var(--panel-bg);
+  color: var(--text);
   font-size: 0.95rem;
 }
 
@@ -148,10 +195,10 @@ input[type="number"] {
 }
 
 .mode-card {
-  background: white;
+  background: var(--panel-bg);
   padding: 20px;
   border-radius: 20px;
-  box-shadow: 0 8px 24px rgba(35, 24, 84, 0.08);
+  box-shadow: var(--panel-shadow-soft);
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -167,18 +214,18 @@ button {
   border-radius: 12px;
   font-size: 1rem;
   cursor: pointer;
-  background: #e8e4ff;
-  color: #1c1b29;
+  background: var(--button-bg);
+  color: var(--button-text);
 }
 
 button.primary {
-  background: #6d5afc;
+  background: var(--accent);
   color: white;
 }
 
 button.ghost {
   background: transparent;
-  border: 1px solid #d7d2f0;
+  border: 1px solid var(--ghost-border);
 }
 
 button:disabled {


### PR DESCRIPTION
### Motivation
- UI にダークテーマを追加して視認性を向上させ、好みに合わせた表示を可能にする。 
- ユーザーのテーマ選択を保存して次回表示時にも同じテーマが適用されるようにする。 

### Description
- ヘッダーにテーマ切替ボタン `#theme-toggle` を追加してトグル操作を提供（`index.html` を更新）。
- CSS 変数と `html[data-theme="dark"]` を導入してライト/ダークの配色を切り替えられるようにした（`styles.css` を更新）。
- `getPreferredTheme` と `applyTheme` を実装し、`localStorage` へ選択を保存して読み込み時に初期テーマを適用するロジックを追加した（`app.js` を更新）。
- ボタンのラベルと `aria-pressed` を更新するハンドラを追加し、ロード時にテーマを初期化するようにした（`app.js` にトグルイベントを追加）。

### Testing
- 開発用に `python -m http.server` で静的ホスティングを起動してページを表示する準備を行った（起動は成功）。
- `Playwright` を使って `#theme-toggle` をクリックしてスクリーンショットを取得する自動テストを実行しようとしたが、ブラウザプロセスのクラッシュによりテストは失敗した。 
- ユニットテストは追加しておらず、他の自動テストは実行していない。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b7aba27788333aabde9b388b51c3a)