### PR TITLE
Playwright の事前セットアップを追加し、クラッカーを最前面に表示

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "@playwright/test": "^1.49.0"
   },
   "scripts": {
+    "pretest": "npm ci && npx playwright install --with-deps",
+    "pretest:screenshot": "npm ci && npx playwright install --with-deps",
     "test": "playwright test",
     "test:screenshot": "playwright test tests/theme-toggle.spec.js"
   }

--- a/styles.css
+++ b/styles.css
@@ -473,6 +473,7 @@ input[type="number"] {
   width: 100%;
   height: 100%;
   pointer-events: none;
+  z-index: 9999;
   display: none;
 }
 


### PR DESCRIPTION
### Motivation
- 紙吹雪（クラッカー）キャンバスが他の要素の背後に隠れて見えない問題を解消したい。 
- Playwright のスクリーンショットテストが環境に依存して失敗するため、テスト実行前に依存関係とブラウザを自動セットアップしたい。 

### Description
- `styles.css` の `.confetti` セレクタに `z-index: 9999` を追加して最前面に表示するようにしました。 
- `package.json` に `pretest` と `pretest:screenshot` スクリプトを追加し、`npm ci` と `npx playwright install --with-deps` を実行するようにしました。 
- テストスクリプトは既存の `test` / `test:screenshot` を維持しつつ、事前セットアップを自動化しました。 

### Testing
- `npm run test:screenshot -- --reporter=line` を実行し、Playwright の依存インストールとブラウザのダウンロードが行われることを確認しました。 
- 同コマンドで `tests/theme-toggle.spec.js` が実行され `1 passed` となりテストは成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d1017ccf083339ec2351b214c9efc)