### PR TITLE
しゃがむ/キープ中に九九の割り算クイズを表示し、立つで解答を表示

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,10 @@
           <div class="timer">
             <div id="phase-timer" class="timer-value">05</div>
             <div id="phase-hint" class="timer-hint">スタートまでカウントダウン</div>
+            <div class="quiz-area" aria-live="polite">
+              <div id="quiz-problem" class="quiz-problem">問題: --</div>
+              <div id="quiz-answer" class="quiz-answer">答え: --</div>
+            </div>
             <div class="progress">
               <div id="progress-bar" class="progress-bar"></div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -281,6 +281,26 @@ body::after {
   margin-bottom: 12px;
 }
 
+.quiz-area {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 12px;
+  padding: 10px 14px;
+  background: var(--surface-muted);
+  border-radius: 16px;
+  border: 1px solid var(--surface-border);
+}
+
+.quiz-problem,
+.quiz-answer {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.quiz-answer {
+  color: var(--accent-2);
+}
+
 .progress {
   width: 100%;
   height: 10px;


### PR DESCRIPTION
### Motivation
- しゃがむ・キープの時間に九九（1〜9の掛け算に対応する割り算）問題を出題して、立ち上がる時間に答えを表示することでワークアウト中に簡単な脳トレを提供するため。 
- 問題はランダムかつ九九で割り切れる（被除数 = 割る数 × 積）ものに限定する必要があるため、専用の生成ロジックを追加した。 
- UI 上で視認できる場所にクイズ領域を設け、アクセシビリティのために `aria-live` を設定した。

### Description
- UI: `index.html` にクイズ表示領域を追加し、`aria-live=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69619efcfc6483339c7dd3a9c5fad3fe)