### PR TITLE
ワークアウト開始前の入力検証と開始/リセット時のUI整合性を改善

### DIFF
--- a/app.js
+++ b/app.js
@@ -566,14 +566,56 @@ const tick = () => {
   }
 };
 
+const parsePositiveInt = (value) => {
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 1 ? parsed : null;
+};
+
+const validateWorkoutInputs = () => {
+  const totalSetsValue = parsePositiveInt(setCountInput.value);
+  const repsPerSetValue = parsePositiveInt(repCountInput.value);
+  const downSeconds = parsePositiveInt(downDurationInput.value);
+  const holdSeconds = parsePositiveInt(holdDurationInput.value);
+  const upSeconds = parsePositiveInt(upDurationInput.value);
+  const restSeconds = parsePositiveInt(restDurationInput.value);
+  const countdownSeconds = parsePositiveInt(countdownDurationInput.value);
+
+  if (
+    !totalSetsValue
+    || !repsPerSetValue
+    || !downSeconds
+    || !holdSeconds
+    || !upSeconds
+    || !restSeconds
+    || !countdownSeconds
+  ) {
+    phaseHint.textContent = '入力値が不正です。セット数・回数・各秒数は1以上で入力してください。';
+    return null;
+  }
+
+  return {
+    totalSetsValue,
+    repsPerSetValue,
+  };
+};
+
 const startWorkout = () => {
-  totalSets = parseInt(setCountInput.value, 10);
-  repsPerSet = parseInt(repCountInput.value, 10);
+  if (workoutStarted || currentPhase !== Phase.IDLE) {
+    return;
+  }
+  const validatedInputs = validateWorkoutInputs();
+  if (!validatedInputs) {
+    return;
+  }
+  totalSets = validatedInputs.totalSetsValue;
+  repsPerSet = validatedInputs.repsPerSetValue;
   currentSet = 1;
   currentRep = 1;
   isPaused = false;
   workoutStarted = true;
   workoutSaved = false;
+  startButton.disabled = true;
+  startButton.textContent = '進行中';
   updateSessionStats();
   startCountdown('スタートまでカウントダウン', () => {
     startPhaseCycle();
@@ -612,6 +654,8 @@ const resetWorkout = () => {
   isPaused = false;
   workoutStarted = false;
   workoutSaved = false;
+  startButton.disabled = false;
+  startButton.textContent = 'スタート';
   pauseButton.textContent = '一時停止';
   phaseTimer.textContent = '05';
   phaseHint.textContent = 'スタートまでカウントダウン';


### PR DESCRIPTION
### Motivation
- ユーザーが不正な値でワークアウトを開始してしまうのを防ぐため、各入力値の妥当性チェックを追加する必要があった。 
- 同時に多重で開始されるのを防ぐガードが必要だった。
- ワークアウト開始後に開始ボタンが無効化されずリセット後の文言や状態がずれる問題を解消するため、UI状態の同期を行う。 

### Description
- `parsePositiveInt` ヘルパーを追加して `parseInt` 結果が `Number.isFinite` かつ `>= 1` であることを判定するようにした。 
- `validateWorkoutInputs` を追加し、`set-count` / `rep-count` / 各 duration 入力を検証して不正な場合は `phaseHint` にエラーメッセージを表示して開始を中止するようにした。 
- `startWorkout` に `workoutStarted || currentPhase !== Phase.IDLE` の早期リターンガードを追加し、入力が有効な場合に `totalSets`/`repsPerSet` を設定して `startButton.disabled = true` と `startButton.textContent = '進行中'` を設定するようにした。 
- `resetWorkout` で開始状態を初期化する際に `startButton.disabled = false` と `startButton.textContent = 'スタート'` を復帰させるようにした。 

### Testing
- ローカルHTTPサーバーを起動するコマンド `python -m http.server 8000` を使ってページを読み込み、Playwrightでページのスクリーンショット取得は成功した（ページのレンダリング確認）。
- Playwrightで `#start-button` をクリックしてワークアウト開始を試みる操作はタイムアウトにより失敗し、開始クリックの自動検証は完了しなかった（部分失敗）。
- 変更は `app.js` に適用され、ファイルはコミットされていることを確認した（自動単体テストは未実行）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961a71ae5808333a5e2ed0819191c6f)