### PR TITLE
Playwrightテスト実行手順をAGENTS.mdに追記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,6 @@
 # Agent Instructions
 
 - 回答は日本語で行うこと。
+- Playwrightテストは次の手順で実行すること（再現性を保ち成功させるための必須手順）:
+  1. `npm test` を実行する（`pretest`で`npm ci`と`npx playwright install --with-deps`が自動実行される）。
+  2. もし特定テストのみ実行する場合は `npm run test:screenshot` を使う（`pretest:screenshot`で依存関係とブラウザが整う）。


### PR DESCRIPTION
### Motivation
- リポジトリでPlaywrightを使ったテストを安定して実行するための手順がドキュメント化されていなかった。 
- `pretest`スクリプトで依存関係とブラウザを整える必要があるため、実行手順を明示して再現性を担保したい。 

### Description
- `AGENTS.md` にPlaywrightテストの実行手順を追記しました。 
- 追加した手順は `npm test` と特定テスト向けの `npm run test:screenshot` の利用法を説明しています。 
- それぞれの手順で `pretest`/`pretest:screenshot` により `npm ci` と `npx playwright install --with-deps` が実行されることを明記しています。 

### Testing
- ドキュメント変更のため自動テストは実行していません。 
- 既存のPlaywright設定は `playwright.config.js` と `tests/theme-toggle.spec.js` が存在する状態です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961a8f6ea2c833395cf6ec5cf2603fe)