### PR TITLE
アクセシビリティ向上とモーション低減対応を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,9 +89,9 @@
           </div>
 
           <div class="actions">
-            <button id="start-button" class="primary">スタート</button>
-            <button id="pause-button">一時停止</button>
-            <button id="reset-button" class="ghost">リセット</button>
+            <button id="start-button" class="primary" aria-label="セッションを開始" aria-pressed="false">スタート</button>
+            <button id="pause-button" aria-label="セッションを一時停止/再開" aria-pressed="false">一時停止</button>
+            <button id="reset-button" class="ghost" aria-label="セッションをリセット">リセット</button>
           </div>
         </div>
 

--- a/styles.css
+++ b/styles.css
@@ -507,6 +507,20 @@ input[type="number"] {
   animation: rise 0.7s ease forwards;
 }
 
+.reduced-motion .reveal {
+  animation: none;
+  opacity: 1;
+  transform: none;
+}
+
+.reduced-motion .progress-bar {
+  transition: none;
+}
+
+.reduced-motion .confetti.active {
+  display: none;
+}
+
 .delay-1 {
   animation-delay: 0.1s;
 }
@@ -539,6 +553,22 @@ input[type="number"] {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .progress-bar {
+    transition: none;
+  }
+
+  .confetti.active {
+    display: none;
   }
 }
 


### PR DESCRIPTION
### Motivation
- 主要操作ボタンにアクセシビリティ属性を追加してスクリーンリーダやキーボード操作を改善するため。 
- スペース/Enterで `start` / `pause` を操作できるキーボードショートカットを追加するため。 
- ユーザーの `prefers-reduced-motion` に従ってタイマー進捗や紙吹雪アニメーションを抑制し、視覚的負担を減らすため。 

### Description
- `index.html` にてセッション操作ボタンに `aria-label` と `aria-pressed` を追加して状態を明示化しました（`start-button` / `pause-button` / `reset-button`）。
- `app.js` に `prefersReducedMotion` 検出、`applyReducedMotionPreference`、`updateActionButtonStates` を導入し、ワークアウト開始/一時停止/終了時に `aria-pressed` を更新するようにしました。 
- 同ファイルでドキュメントの `keydown` を監視し、フォーカス中の入力要素を除外した上でスペースまたは `Enter` で `startWorkout()`／`pauseWorkout()` を切替える実装を追加しました。 
- 紙吹雪（`launchConfetti`）と進捗バーのアニメーションを `reduced-motion` に応じて抑制・簡素化するロジックと、`styles.css` に `reduced-motion` クラスおよび `@media (prefers-reduced-motion: reduce)` ルールを追加しました。 

### Testing
- `runTests()` 内のコンソールアサーションが実行され、`Test run completed.` が出力されて成功しました。 
- ヘッドレス Playwright スクリプトでアプリを読み込み、ページのスクリーンショットを `artifacts/squat-tracker.png` に作成してロードを確認しました。 
- 自動テストフレームワーク（`npm test` 等）のフルスイートは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961ab39976483338a2b18be08ae108a)