### PR TITLE
feat: add settings modal and data reset functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,13 +19,16 @@
   <main class="app">
     <header class="hero">
       <div class="hero-copy">
-        <div class="theme-toggle" aria-label="テーマ切替">
-          <span class="theme-label">Theme</span>
-          <label class="switch">
-            <input id="theme-toggle" type="checkbox" data-theme-toggle />
-            <span class="slider"></span>
-            <span id="theme-status" class="switch-label">ライト</span>
-          </label>
+        <div class="header-controls">
+          <div class="theme-toggle" aria-label="テーマ切替">
+            <span class="theme-label">Theme</span>
+            <label class="switch">
+              <input id="theme-toggle" type="checkbox" data-theme-toggle />
+              <span class="slider"></span>
+              <span id="theme-status" class="switch-label">ライト</span>
+            </label>
+          </div>
+          <button id="open-settings" class="ghost icon-button" aria-label="設定" style="font-size: 1.5rem; padding: 0.25rem; line-height: 1; border: none; cursor: pointer;">⚙️</button>
         </div>
         <div id="voice-status-indicator" class="voice-status-indicator hidden" aria-label="音声認識状態">
           <span class="mic-icon">🎙️</span>
@@ -811,6 +814,23 @@
         <div class="scheduler-footer">
           <button id="save-schedule-button" class="primary full-width">スケジュールを作成</button>
           <button id="clear-schedule-button" class="ghost small" style="margin-top: 0.5rem; width: 100%;">設定を削除</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+    <div id="settings-modal" class="modal" aria-hidden="true">
+    <div class="modal-overlay" tabindex="-1" data-close></div>
+    <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="settings-modal-title">
+      <div class="modal-header">
+        <h2 id="settings-modal-title">設定</h2>
+        <button class="ghost small close-modal" aria-label="閉じる" data-close>✕</button>
+      </div>
+      <div class="modal-body">
+        <div class="settings-section">
+          <h3>データ管理</h3>
+          <p class="settings-desc">アプリケーションの全データを削除し、初期状態に戻します。この操作は取り消せません。</p>
+          <button id="reset-all-data" class="danger full-width">全てのデータを初期化</button>
         </div>
       </div>
     </div>

--- a/js/app.js
+++ b/js/app.js
@@ -2105,6 +2105,36 @@ const initApp = async () => {
     });
   }
 
+
+  // Settings Modal
+  const openSettingsBtn = document.getElementById('open-settings');
+  const settingsModal = document.getElementById('settings-modal');
+  const resetAllDataBtn = document.getElementById('reset-all-data');
+
+  if (openSettingsBtn && settingsModal) {
+    openSettingsBtn.addEventListener('click', () => {
+      settingsModal.classList.add('active');
+      settingsModal.setAttribute('aria-hidden', 'false');
+    });
+
+    const closeBtns = settingsModal.querySelectorAll('[data-close]');
+    closeBtns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        settingsModal.classList.remove('active');
+        settingsModal.setAttribute('aria-hidden', 'true');
+      });
+    });
+  }
+
+  if (resetAllDataBtn) {
+    resetAllDataBtn.addEventListener('click', () => {
+      if (confirm(`本当に全てのデータを削除しますか？\nこの操作は取り消せません。\nプレイ履歴、設定、獲得したアイテムなど全てが失われます。`)) {
+        localStorage.clear();
+        location.reload();
+      }
+    });
+  }
+
 };
 
 if (document.readyState === 'loading') {

--- a/tests/settings.spec.js
+++ b/tests/settings.spec.js
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Settings and Data Reset', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for the app to be fully interactive
+    // We check for the settings button to be present in the DOM
+    await page.waitForSelector('#open-settings', { state: 'attached' });
+  });
+
+  test('Settings modal opens and closes correctly', async ({ page }) => {
+    const settingsButton = page.locator('#open-settings');
+    await expect(settingsButton).toBeVisible();
+
+    await settingsButton.click();
+
+    const modal = page.locator('#settings-modal');
+    await expect(modal).toHaveClass(/active/);
+    await expect(modal).toHaveAttribute('aria-hidden', 'false');
+
+    const resetButton = page.locator('#reset-all-data');
+    await expect(resetButton).toBeVisible();
+
+    const closeButton = modal.locator('.close-modal');
+    await closeButton.click();
+
+    await expect(modal).not.toHaveClass(/active/);
+    await expect(modal).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('Reset Data button triggers confirmation', async ({ page }) => {
+    await page.locator('#open-settings').click();
+
+    let dialogMessage = '';
+    page.once('dialog', async dialog => {
+      dialogMessage = dialog.message();
+      await dialog.dismiss();
+    });
+
+    const resetButton = page.locator('#reset-all-data');
+    await resetButton.click();
+
+    expect(dialogMessage).toContain('本当に全てのデータを削除しますか？');
+  });
+});


### PR DESCRIPTION
- Added a "Settings" button (gear icon) to the header in `index.html`.
- Implemented a Settings Modal with a "Reset All Data" button.
- Added logic in `js/app.js` to handle modal toggling and data reset (localStorage clear + reload) with confirmation.
- Added `tests/settings.spec.js` to verify the new functionality.
- Fixed `index.html` structure to include a wrapper for header controls.

---
*PR created automatically by Jules for task [16792570629118770948](https://jules.google.com/task/16792570629118770948) started by @eburairu*